### PR TITLE
IsRoot method

### DIFF
--- a/atlas.go
+++ b/atlas.go
@@ -29,6 +29,11 @@ func New() *Node {
 	return n
 }
 
+// IsRoot checks if the current Node is the root
+func (n *Node) IsRoot() bool {
+	return n.root == n
+}
+
 // ValueByKey gets the value of key written in this Node or any of it's ancestors
 func (n *Node) ValueByKey(k string) (string, bool) {
 	if n.root == n {

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -102,6 +102,15 @@ func TestNodeContains(t *testing.T) {
 	require.False(t, n3.Contains(n2)) // B7,C4 | B7,C6
 }
 
+func TestNodeIsRoot(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	assert.True(t, r.IsRoot())
+	subnode := r.AddLink("key1", "val1")
+	assert.False(t, subnode.IsRoot())
+}
+
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // from https://stackoverflow.com/a/22892986/5427244


### PR DESCRIPTION
The caller can check if the Node is a Root, so it can check faster if the Path is empty.