### PR TITLE
Add a pseudo-random and reproducible concurrent test

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,6 +28,4 @@ jobs:
           set -x
           which go
           go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
-          go test "${args[@]}" -timeout 800s ./...
+          go test -race -timeout 100s ./...

--- a/atlas.go
+++ b/atlas.go
@@ -11,6 +11,10 @@ import (
 
 type linkKeyType [2]string
 
+func (lkt linkKeyType) String() string {
+	return "{" + lkt[0] + ": " + lkt[1] + "}"
+}
+
 // Node is a node in the atlas
 // it is unique per Root and can directly be compared  with `==` to another Node
 type Node struct {
@@ -27,6 +31,13 @@ func New() *Node {
 	n.root = n
 	n.prev = n
 	return n
+}
+
+func (n *Node) String() string {
+	if n.IsRoot() {
+		return "/"
+	}
+	return n.prev.String() + "/" + n.linkKey.String()
 }
 
 // IsRoot checks if the current Node is the root

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -289,11 +289,19 @@ func TestFinalNodesEquality(t *testing.T) {
 	// Starting from the root, if we add the same tag keys and values, but in
 	// different order, we expect to arrive at the same final node
 	subsetTestCount := th.randInt(15, 30)
+	tagSets := make([][]linkKeyType, subsetTestCount)
+	// We generate the tags sets before we test with VUs, so the RNG numbers
+	// that influence the key and tag picking are not affected by VU counts
 	for i := 0; i < subsetTestCount; i++ {
 		keysCount := th.randInt(len(th.tagKeys)/2, len(th.tagKeys)) // do not generally use all keys
-		tags := th.getOneTagPerKey(keysCount)
-		t.Logf("Final node equality test with %d/%d with tags for %d keys: %q", i+1, subsetTestCount, keysCount, tags)
-		testFinalNodesEquality(th, []*Node{root}, tags)
+		tagSets[i] = th.getOneTagPerKey(keysCount)
+	}
+	for i := 0; i < subsetTestCount; i++ {
+		t.Logf(
+			"Final node equality test with %d/%d with tags for %d keys: %q",
+			i+1, subsetTestCount, len(tagSets[i]), tagSets[i],
+		)
+		testFinalNodesEquality(th, []*Node{root}, tagSets[i])
 	}
 
 	// Add all of the observed nodes in the set of starting nodes, because...

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,193 @@ func randSeq() string {
 		b[i] = letters[rand.Intn(len(letters))] //nolint:gosec
 	}
 	return string(b)
+}
+
+// test helper for pseudo-reproducibly-random and concurrent atlas tests
+type testHelper struct {
+	t    *testing.T
+	rand *rand.Rand
+
+	tags           []linkKeyType
+	tagKeys        []string
+	tagValuesByKey map[string][]string
+}
+
+func newTestHelper(t *testing.T, keyCountFrom, keyCountTo, valuesPerKeyFrom, valuesPerKeyTo int) *testHelper {
+	seed := time.Now().UnixNano()
+	r := rand.New(rand.NewSource(seed)) //nolint:gosec
+
+	th := &testHelper{
+		t:    t,
+		rand: r,
+	}
+
+	tagKeyCount := th.randInt(keyCountFrom, keyCountTo)
+	t.Logf("RandomSource=%d, tagKeyCount=%d\n", seed, tagKeyCount)
+
+	th.tagKeys = make([]string, tagKeyCount)
+	th.tagValuesByKey = make(map[string][]string, tagKeyCount)
+	for i := 0; i < tagKeyCount; i++ {
+		key := th.randString(5, 30)
+		th.tagKeys[i] = key
+
+		valuesForKeyCount := th.randInt(valuesPerKeyFrom, valuesPerKeyTo)
+		values := make([]string, valuesForKeyCount)
+		t.Logf("Generating %d tag values for tag '%s'...", valuesForKeyCount, key)
+		for j := 0; j < valuesForKeyCount; j++ {
+			value := th.randString(10, 100)
+			values[j] = value
+			th.tags = append(th.tags, linkKeyType{key, value})
+		}
+		th.tagValuesByKey[key] = values
+	}
+
+	t.Logf("Generated %d tag pairs in total: %q", len(th.tags), th.tagValuesByKey)
+	return th
+}
+
+func (th *testHelper) randInt(from, to int) int {
+	return from + th.rand.Intn(to-from)
+}
+
+func (th *testHelper) randString(minLen, maxLen int) string {
+	b := make([]byte, th.randInt(minLen, maxLen))
+	for i := range b {
+		b[i] = letters[th.randInt(0, len(letters))]
+	}
+	return string(b)
+}
+
+// https://en.wikipedia.org/wiki/Euclidean_algorithm#Implementations
+func (th *testHelper) areCoPrime(a, b int) bool {
+	var t int
+	for b != 0 {
+		t = b
+		b = a % b
+		a = t
+	}
+	return a == 1
+}
+
+// https://lemire.me/blog/2017/09/18/visiting-all-values-in-an-array-exactly-once-in-random-order/
+func (th *testHelper) getRandCoPrimeAndOffset(num int) (int, int) {
+	randOffset := th.randInt(2, 10*num) // doesn't really matter
+	th.t.Logf("Generating a random co-prime and offset (%d) to iterate pseudo-randomly over %d elements", randOffset, num)
+	for {
+		c := th.randInt(1+num/2, 10*num) // doesn't really matter
+		th.t.Logf("Checking to see if %d and %d are co-prime...", num, c)
+		if th.areCoPrime(num, c) {
+			return c, randOffset
+		}
+	}
+}
+
+func (th *testHelper) getOneTagPerKey(maxKeys int) []linkKeyType {
+	keysLen := len(th.tagKeys)
+	res := make([]linkKeyType, maxKeys)
+
+	step, offset := th.getRandCoPrimeAndOffset(keysLen)
+	for i := 0; i < maxKeys; i++ {
+		// https://lemire.me/blog/2017/09/18/visiting-all-values-in-an-array-exactly-once-in-random-order/
+		key := th.tagKeys[(i*step+offset)%keysLen]
+		values := th.tagValuesByKey[key]
+		res[i] = linkKeyType{key, values[th.randInt(0, len(values))]}
+	}
+
+	return res
+}
+
+func testFinalNodesEquality(th *testHelper, startingNodes []*Node, tags []linkKeyType) {
+	tagsLen := len(tags)
+	vusCount := th.randInt(2, 5)
+	vusReady := &sync.WaitGroup{}
+	vusReady.Add(vusCount)
+	startVUs := make(chan struct{})
+	vusDone := &sync.WaitGroup{}
+	vusDone.Add(vusCount)
+
+	finalNodes := make([]*Node, vusCount)
+	for i := 0; i < vusCount; i++ {
+		randStep, randOffset := th.getRandCoPrimeAndOffset(tagsLen)
+		randStartingNode := th.randInt(0, len(startingNodes))
+		th.t.Logf(
+			"VU %d will use starting Node %d, co-prime %d, offset %d to iterate over %d elements",
+			i, randStartingNode, randStep, randOffset, tagsLen,
+		)
+		go func(vuID, startNode, step, offset int) {
+			vusReady.Done()
+			<-startVUs // start all VUs as simultaneously as possible
+			n := startingNodes[startNode]
+			myNodes := make([]*Node, tagsLen)
+			for j := 0; j < tagsLen; j++ {
+				tagIndex := (j*randStep + offset) % tagsLen
+				// th.t.Logf("VU %03d iterates over index %03d (%s)", vuID, tagIndex, tags[tagIndex])
+				n = n.add(tags[tagIndex][0], tags[tagIndex][1])
+				myNodes[j] = n
+			}
+			finalNodes[vuID] = n
+			vusDone.Done()
+		}(i, randStartingNode, randStep, randOffset)
+	}
+
+	vusReady.Wait()
+	close(startVUs)
+	vusDone.Wait()
+
+	for i := 1; i < vusCount; i++ {
+		if finalNodes[0] != finalNodes[i] {
+			th.t.Errorf("Final node 0 is not equal to final node %d:\n\t%s\n\t%s", i, finalNodes[0], finalNodes[i])
+		}
+	}
+}
+
+func getAllNodes(root *Node) []*Node {
+	seen := map[*Node]struct{}{}
+	nodes := []*Node{}
+	var addNodes func(n *Node)
+	addNodes = func(n *Node) {
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			nodes = append(nodes, n)
+		}
+		n.links.Range(func(key, value any) bool {
+			addNodes(value.(*Node)) //nolint:forcetypeassert
+			return true
+		})
+	}
+	addNodes(root)
+	return nodes
+}
+
+func TestFinalNodesEquality(t *testing.T) {
+	t.Parallel()
+
+	th := newTestHelper(t, 10, 20, 5, 50)
+
+	root := New()
+	// Starting from the root, if we add the same tag keys and values, but in
+	// different order, we expect to arrive at the same final node
+	subsetTestCount := th.randInt(15, 30)
+	for i := 0; i < subsetTestCount; i++ {
+		keysCount := th.randInt(len(th.tagKeys)/2, len(th.tagKeys)) // do not generally use all keys
+		tags := th.getOneTagPerKey(keysCount)
+		t.Logf("Final node equality test with %d/%d with tags for %d keys: %q", i+1, subsetTestCount, keysCount, tags)
+		testFinalNodesEquality(th, []*Node{root}, tags)
+	}
+
+	// Add all of the observed nodes in the set of starting nodes, because...
+	startingNodes := getAllNodes(root)
+	t.Logf("Gathered %d starting nodes!", len(startingNodes))
+
+	// ... if we start at any node, but we make sure to add exactly one tag with
+	// every key, we still expect to arrive at the same final node, even if we
+	// add the tags in a different order from every VU
+	allTagsTestCount := th.randInt(15, 30)
+	for i := 0; i < allTagsTestCount; i++ {
+		tags := th.getOneTagPerKey(len(th.tagKeys)) // use tags from all keys
+		t.Logf("Final node equality test with %d/%d with tags for all keys: %q", i+1, subsetTestCount, tags)
+		testFinalNodesEquality(th, startingNodes, tags)
+	}
 }
 
 func TestConcurrency(t *testing.T) {

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -297,8 +297,9 @@ func TestFinalNodesEquality(t *testing.T) {
 
 	// Add all of the observed nodes in the set of starting nodes, because...
 	t.Logf("Gathering all graph nodes...")
+	startTime := time.Now()
 	startingNodes := getAllNodes(root)
-	t.Logf("Gathered %d starting nodes!", len(startingNodes))
+	t.Logf("Gathered %d starting nodes for %s!", len(startingNodes), time.Since(startTime))
 
 	// ... if we start at any node, but we make sure to add exactly one tag with
 	// every key, we still expect to arrive at the same final node, even if we

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -266,10 +266,11 @@ func getAllNodes(root *Node) []*Node {
 	nodes := []*Node{}
 	var addNodes func(n *Node)
 	addNodes = func(n *Node) {
-		if _, ok := seen[n]; !ok {
-			seen[n] = struct{}{}
-			nodes = append(nodes, n)
+		if _, ok := seen[n]; ok {
+			return
 		}
+		seen[n] = struct{}{}
+		nodes = append(nodes, n)
 		n.links.Range(func(key, value any) bool {
 			addNodes(value.(*Node)) //nolint:forcetypeassert
 			return true

--- a/atlas_test.go
+++ b/atlas_test.go
@@ -219,7 +219,7 @@ func (th *testHelper) getOneTagPerKey(maxKeys int) []linkKeyType {
 
 func testFinalNodesEquality(th *testHelper, startingNodes []*Node, tags []linkKeyType) {
 	tagsLen := len(tags)
-	vusCount := th.randInt(2, 5)
+	vusCount := th.randInt(20, 50)
 	vusReady := &sync.WaitGroup{}
 	vusReady.Add(vusCount)
 	startVUs := make(chan struct{})
@@ -282,7 +282,7 @@ func getAllNodes(root *Node) []*Node {
 func TestFinalNodesEquality(t *testing.T) {
 	t.Parallel()
 
-	th := newTestHelper(t, 10, 20, 5, 50)
+	th := newTestHelper(t, 10, 30, 5, 50)
 
 	root := New()
 	// Starting from the root, if we add the same tag keys and values, but in
@@ -296,6 +296,7 @@ func TestFinalNodesEquality(t *testing.T) {
 	}
 
 	// Add all of the observed nodes in the set of starting nodes, because...
+	t.Logf("Gathering all graph nodes...")
 	startingNodes := getAllNodes(root)
 	t.Logf("Gathered %d starting nodes!", len(startingNodes))
 


### PR DESCRIPTION
It is "slightly" over-engineered, but it should give some assurance that the same tag sets will result in the same Nodes, even under heavy concurrency and weird usage.

Besides, the `testHelper` will probably be useful for other tests too... :sweat_smile: :crossed_fingers: 